### PR TITLE
Use a deterministic RNG for the KS tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BATTestCases"
 uuid = "91d0e2c9-dbaa-453b-b50b-030d574b201f"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/test/test_funnel.jl
+++ b/test/test_funnel.jl
@@ -37,13 +37,16 @@ using HypothesisTests
     @test isapprox(@inferred(Distributions._logpdf(funnel, [0., 0., 0.])), -2.75681, atol = 1e-5)
 
     #KS Test
+    # Deterministic RNG, so the KS tests below can't fail by chance:
+    rng = BATTestCases.determ_rng()
+
     #Test the constant-variance Gaussian
     funnel = FunnelDistribution(a = 1., b = 0., n = 1)
-    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(funnel, 10^6)[:], Normal(0., 1.))
-    @test pvalue(ks_test) > 0.01  # ToDo: Try to increase to 0.05
-    
+    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(rng, funnel, 10^6)[:], Normal(0., 1.))
+    @test pvalue(ks_test) > 0.01
+
     #Test the variable-variance Gaussian
     funnel = FunnelDistribution(a = 0., b = 0., n = 2)
-    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(funnel, 10^6)[2,:], Normal(0., 1.))
-    @test pvalue(ks_test) > 0.01  # ToDo: Try to increase to 0.05
+    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(rng, funnel, 10^6)[2,:], Normal(0., 1.))
+    @test pvalue(ks_test) > 0.01
 end

--- a/test/test_multimodal_student_t.jl
+++ b/test/test_multimodal_student_t.jl
@@ -52,20 +52,23 @@ using HypothesisTests
     #logpdf
     @test @inferred(Distributions._logpdf(mt, [-1., 0., 1., 2.])) == -11.283438151658
 
+    # Deterministic RNG, so the KS tests below can't fail by chance:
+    rng = BATTestCases.determ_rng()
+
     #If μ = 0, d = 1 the Distribution should be Cauchy-like in every dimension
     mmc = MultimodalStudentT(μ = 0., σ = 0.1, ν = 1, n=2)
-    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(mmc, 10^6)[1,:], Cauchy(0., 0.1))#First dimension
-    @test pvalue(ks_test) > 0.01  # ToDo: Try to increase to 0.05
-    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(mmc, 10^6)[2,:], Cauchy(0., 0.1))#Second dimension
-    @test pvalue(ks_test) > 0.01  # ToDo: Try to increase to 0.05
+    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(rng, mmc, 10^6)[1,:], Cauchy(0., 0.1))#First dimension
+    @test pvalue(ks_test) > 0.01
+    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(rng, mmc, 10^6)[2,:], Cauchy(0., 0.1))#Second dimension
+    @test pvalue(ks_test) > 0.01
 
     #If μ = 0, ν > 1 the Distribution should be Student t-like in every dimension
     mmc = MultimodalStudentT(μ = 0., σ = 0.1, ν = 3, n=4)
     tdist = 0.1 * TDist(3)
-    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(mmc, 10^6)[1,:], tdist)
-    @test pvalue(ks_test) > 0.01  # ToDo: Try to increase to 0.05
-    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(mmc, 10^6)[2,:], tdist)
-    @test pvalue(ks_test) > 0.01  # ToDo: Try to increase to 0.05
+    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(rng, mmc, 10^6)[1,:], tdist)
+    @test pvalue(ks_test) > 0.01
+    ks_test = HypothesisTests.ExactOneSampleKSTest(rand(rng, mmc, 10^6)[2,:], tdist)
+    @test pvalue(ks_test) > 0.01
 
     @test ~any(isnan, Statistics.var(mmc))
     @test ~any(isnan, Statistics.mean(mmc))


### PR DESCRIPTION
CI has been failing intermittently, e.g. [run 32595711788](https://github.com/bat/BATTestCases.jl/actions/runs/32595711788/job/97181483979).

## Root cause

Not a regression: commit `ea1de5b` passed in run `32594304131` and failed in run `32595711788` — same tree, different outcome. In the earlier failed run `32593989951`, three separate jobs failed at three *different* KS assertions (`test_funnel.jl:43` with p=0.0087, `test_multimodal_student_t.jl:58` with p=0.0088, and `:66`), all just below the threshold.

The six Kolmogorov-Smirnov tests in `test_funnel.jl` and `test_multimodal_student_t.jl` sampled from the unseeded global RNG and asserted `p > 0.01`. Under the null hypothesis a single run therefore fails with probability `1 - 0.99^6 ≈ 5.8%`, and across the CI matrix some job goes red on roughly a third of all pushes.

Running the six assertions 60 times each with independent seeds (360 p-values) confirms the distributions themselves are fine: a KS test of those p-values against `Uniform()` gives p = 0.65, and the fraction below 0.01 is 1.11%, i.e. exactly the nominal rate.

## Fix

Draw the samples from `BATTestCases.determ_rng()` (`Philox4x`, counter-based and stable across Julia versions), which the package already uses for its deterministic covariance calculations. One RNG per test file, advancing across the assertions so each test sees a different part of the stream.

The resulting p-values are 0.53, 0.98, 0.14, 0.71, 0.61 and 0.34 — well clear of the threshold with no seed hunting, so the tests keep their full sensitivity at `p > 0.01`.

The `# ToDo: Try to increase to 0.05` comments are dropped: with a fixed RNG a larger threshold adds no sensitivity and would only make the tests more fragile should a future Distributions release change a sampler stream.

Also increases the package version to 0.2.2.

## Verification

`Pkg.test("BATTestCases")` run twice locally: 77/77 pass both times (was 76 pass / 1 fail).