### PR TITLE
Support ArraysOfArrays v1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 ArgCheck = "1, 2"
-ArraysOfArrays = "0.4, 0.5, 0.6"
+ArraysOfArrays = "0.4, 0.5, 0.6, 1"
 Distributions = "0.25"
 DocStringExtensions = "0.8, 0.9"
 QuadGK = "2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BATTestCases"
 uuid = "91d0e2c9-dbaa-453b-b50b-030d574b201f"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"

--- a/src/BATTestCases.jl
+++ b/src/BATTestCases.jl
@@ -10,7 +10,7 @@ module BATTestCases
 using LinearAlgebra
 using Random
 using Statistics
-using ArraysOfArrays: nestedview
+using ArraysOfArrays: VectorOfSimilarVectors
 using ArgCheck: @argcheck
 using Distributions
 using DocStringExtensions

--- a/src/funnel.jl
+++ b/src/funnel.jl
@@ -39,7 +39,7 @@ Base.eltype(d::FunnelDistribution) = Base.eltype(d.a)
 Statistics.mean(d::FunnelDistribution) = zeros(d.n)
 
 function Statistics.cov(dist::FunnelDistribution)
-    cov(nestedview(rand(BATTestCases.determ_rng(), dist, 10^5)))
+    cov(VectorOfSimilarVectors(rand(BATTestCases.determ_rng(), dist, 10^5)))
 end
 
 StatsBase.params(d::FunnelDistribution) = (d.a, d.b, d.n)

--- a/src/gaussian_shell.jl
+++ b/src/gaussian_shell.jl
@@ -81,7 +81,7 @@ function Distributions._logpdf(d::GaussianShell, x::AbstractArray)
 end
 
 function Statistics.cov(d::GaussianShell)
-    cov(nestedview(rand(BATTestCases.determ_rng(), d, 10^5)))
+    cov(VectorOfSimilarVectors(rand(BATTestCases.determ_rng(), d, 10^5)))
 end
 
 Base.length(d::GaussianShell) = length(d.c)


### PR DESCRIPTION
Adds compatibility with ArraysOfArrays v1 while keeping support for v0.4 to v0.6.

`nestedview` is deprecated in ArraysOfArrays v1, the `VectorOfSimilarVectors` constructor used instead is available on all supported versions.

Includes a patch version bump.

Created by generative AI.
